### PR TITLE
Add memory-first responses before OpenAI fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A feature-rich WhatsApp chatbot powered by the [whatsapp-web.js](https://github.
 
 - 🤖 Conversational AI responses backed by `gpt-4o-mini` with configurable system prompt
 - 💬 Rolling context memory per chat (persisted to disk with auto-trimming)
+- 🧠 Memory-first answers for facts you previously shared before asking OpenAI
 - ⚙️ Built-in bot commands (`!help`, `!reset`, `!history`, `!about`)
 - 🙋‍♂️ Friendly predefined replies for common greetings and sentiments
 - 🗃️ Local logging of all bot responses for later review


### PR DESCRIPTION
## Summary
- add keyword-based memory search to reuse facts shared earlier before calling OpenAI
- store predefined and memory-based replies in history/logs and document the capability

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68df488145bc83339339b236a88248af