### PR TITLE
Enhance bot safety and professionalism

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ A feature-rich WhatsApp chatbot powered by the [whatsapp-web.js](https://github.
 - 🤖 Conversational AI responses backed by `gpt-4o-mini` with configurable system prompt
 - 💬 Rolling context memory per chat (persisted to disk with auto-trimming)
 - 🧠 Memory-first answers for facts you previously shared before asking OpenAI
-- ⚙️ Built-in bot commands (`!help`, `!reset`, `!history`, `!about`)
+- ⚙️ Built-in bot commands (`!help`, `!reset`, `!history`, `!policy`, `!privacy`, `!stats`, `!about`)
 - 🙋‍♂️ Friendly predefined replies for common greetings and sentiments
 - 🗃️ Local logging of all bot responses for later review
 - 🔐 Automatic environment validation for the `OPENAI_API_KEY`
+- 🛡️ Safety features including OpenAI moderation, sensitive data detection, and per-chat rate limiting
 
 ## Getting Started
 
@@ -35,6 +36,9 @@ A feature-rich WhatsApp chatbot powered by the [whatsapp-web.js](https://github.
 | `!help`    | Show available commands |
 | `!reset`   | Clear the saved conversation context for the chat |
 | `!history` | Summarise the most recent context that informs replies |
+| `!policy`  | Display the assistant's safety guidelines |
+| `!privacy` | Explain what data is stored and how to clear it |
+| `!stats`   | Share usage insights for the current chat |
 | `!about`   | Learn about the bot |
 
 ## Data Files


### PR DESCRIPTION
## Summary
- strengthen the assistant system prompt and add per-chat rate limiting, message length checks, and sensitive data detection before replying
- integrate OpenAI moderation for both user inputs and bot outputs, with logging and safer fallbacks when content is flagged
- expand built-in commands with policy, privacy, and stats responses plus update documentation to reflect the safety-focused feature set

## Testing
- node --check bot.js

------
https://chatgpt.com/codex/tasks/task_e_68df50f912988333b3e61f62bb2a4138