### PR TITLE
Store quick replies per chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A feature-rich WhatsApp chatbot powered by the [whatsapp-web.js](https://github.
 | `!help`    | Show available commands |
 | `!reset`   | Clear the saved conversation context for the chat |
 | `!history` | Summarise the most recent context that informs replies |
+| `!quickreplies` | List the quick replies the bot has used in this chat |
 | `!policy`  | Display the assistant's safety guidelines |
 | `!privacy` | Explain what data is stored and how to clear it |
 | `!stats`   | Share usage insights for the current chat |
@@ -43,7 +44,7 @@ A feature-rich WhatsApp chatbot powered by the [whatsapp-web.js](https://github.
 
 ## Data Files
 
-- `memory.json`: per-chat rolling conversation history
+- `memory.json`: per-chat rolling conversation history and remembered quick replies
 - `all_responses.json`: log of user prompts and bot replies (trimmed to the most recent 100 entries per chat)
 
 Both files are written relative to `bot.js`. They are automatically created when the bot first runs.


### PR DESCRIPTION
## Summary
- persist per-chat history alongside remembered quick replies
- expose a !quickreplies command and track quick-reply usage statistics
- update documentation to describe the new quick reply memory behaviour

## Testing
- node --check bot.js

------
https://chatgpt.com/codex/tasks/task_e_68df53ad330c8333a62783de961b0d10