### PR TITLE
Load predefined replies from memory

### DIFF
--- a/memory.json
+++ b/memory.json
@@ -1,1 +1,25 @@
-{}
+{
+  "predefinedResponses": [
+    {
+      "keywords": ["hello", "hi", "hey"],
+      "response": "Hello! 👋 How can I assist you today?"
+    },
+    {
+      "keywords": ["good morning", "morning"],
+      "response": "Good morning! ☀️ Hope your day is going well."
+    },
+    {
+      "keywords": ["thank you", "thanks", "thx"],
+      "response": "You're welcome! 😊 Let me know if you need anything else."
+    },
+    {
+      "keywords": ["bye", "goodbye", "see you"],
+      "response": "Goodbye! 👋 Catch you later."
+    },
+    {
+      "keywords": ["who are you", "what is your name"],
+      "response": "I'm Emponyoo, your friendly WhatsApp assistant powered by OpenAI."
+    }
+  ],
+  "chats": {}
+}


### PR DESCRIPTION
## Summary
- normalise memory storage to keep chat history separate from predefined responses
- read predefined replies from memory.json before falling back to OpenAI generated answers
- seed memory.json with example canned replies that can be customised

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df56370ba08333b38165993294b5ad