### PR TITLE
Refactor storage layout and add legal docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Whatsapp Bot
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,28 @@
+# Privacy Policy
+
+_Last updated: October 2024_
+
+This WhatsApp assistant ("the Bot") is designed to respect your privacy. The Bot only stores the information needed to provide contextually relevant replies and to maintain a list of predefined quick responses.
+
+## Information We Collect
+
+* **Conversation Logs:** For each chat, the Bot stores a rolling log of prompts and replies inside `all_responses.json`. Each entry includes the message content, the generated reply, the timestamp, and the reply source (predefined, memory lookup, OpenAI, or safety notice).
+* **Predefined Responses:** The only data saved in `memory.json` is a curated list of predefined trigger phrases and their responses. No personal chat history is written to this file.
+
+## How Information Is Used
+
+The stored data allows the Bot to:
+
+1. Provide short-term context for better answers.
+2. Record which automated responses were used.
+3. Offer safety tooling such as moderation and sensitive-pattern alerts.
+
+The Bot does not share information with third parties beyond sending prompts to the configured OpenAI API for response generation and moderation.
+
+## Data Retention
+
+Conversation history is capped to a limited number of recent entries per chat. You can purge the stored history for a specific chat by sending the `!reset` command.
+
+## Contact
+
+If you have any questions about this policy, please open an issue in the project repository.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A feature-rich WhatsApp chatbot powered by the [whatsapp-web.js](https://github.
 ## Features
 
 - 🤖 Conversational AI responses backed by `gpt-4o-mini` with configurable system prompt
-- 💬 Rolling context memory per chat (persisted to disk with auto-trimming)
+- 💬 Rolling context memory per chat backed by a lightweight on-disk log
 - 🧠 Memory-first answers for facts you previously shared before asking OpenAI
 - ⚙️ Built-in bot commands (`!help`, `!reset`, `!history`, `!policy`, `!privacy`, `!stats`, `!about`)
 - 🙋‍♂️ Friendly predefined replies for common greetings and sentiments
@@ -44,10 +44,16 @@ A feature-rich WhatsApp chatbot powered by the [whatsapp-web.js](https://github.
 
 ## Data Files
 
-- `memory.json`: per-chat rolling conversation history and remembered quick replies
-- `all_responses.json`: log of user prompts and bot replies (trimmed to the most recent 100 entries per chat)
+- `memory.json`: curated list of predefined responses that the bot can answer instantly
+- `all_responses.json`: rolling log of user prompts and bot replies (trimmed to the most recent 100 entries per chat)
 
-Both files are written relative to `bot.js`. They are automatically created when the bot first runs.
+Both files are written relative to `bot.js`. Configuration values (bot name, limits, etc.) live in `config.js` so you can tweak behaviour without editing the main bot file.
+
+## Legal
+
+- [MIT License](./LICENSE)
+- [Privacy Policy](./PRIVACY_POLICY.md)
+- [Terms of Service](./TERMS_OF_SERVICE.md)
 
 ## Development Notes
 

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -1,0 +1,13 @@
+# Terms of Service
+
+_Last updated: October 2024_
+
+By using this WhatsApp assistant ("the Bot"), you agree to the following terms:
+
+1. **No Warranty.** The Bot is provided "as is" without warranties of any kind. Use it at your own risk.
+2. **Acceptable Use.** You will not use the Bot to request or distribute harmful, illegal, or abusive content. The Bot will refuse to engage in such activities.
+3. **Privacy.** Limited conversation history is retained to provide contextual replies, as described in the accompanying Privacy Policy. You are responsible for avoiding the sharing of sensitive personal information.
+4. **API Usage.** Responses are generated with the OpenAI API. You agree to comply with the OpenAI terms of use when interacting with the Bot.
+5. **Updates.** These terms may change over time. Continued use of the Bot after updates constitutes acceptance of the new terms.
+
+If you do not agree to these terms, please discontinue using the Bot.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,46 @@
+const path = require('path');
+
+const BOT_NAME = 'Emponyoo';
+const COMMAND_PREFIX = '!';
+
+const STOPWORDS = new Set([
+    'the', 'and', 'for', 'are', 'but', 'you', 'your', 'with', 'this', 'that', 'have', 'from',
+    'what', 'when', 'where', 'who', 'why', 'how', 'which', 'been', 'were', 'will', 'would',
+    'could', 'should', 'about', 'there', 'here', 'they', 'them', 'their', 'ours', 'ourselves',
+    'him', 'her', 'his', 'hers', 'its', 'our', 'out', 'into', 'onto', 'because', 'been', 'can'
+]);
+
+const SENSITIVE_PATTERNS = [
+    {
+        name: 'payment card number',
+        regex: /\b(?:\d[ -]*?){13,19}\b/,
+        response: 'For your safety, please avoid sharing payment card numbers here. If you need help, try describing the situation without sensitive details.'
+    },
+    {
+        name: 'national ID',
+        regex: /\b\d{3}[- ]?\d{2}[- ]?\d{4}\b/,
+        response: 'I spotted something that looks like a personal identification number. Please keep that private and share only non-sensitive information.'
+    }
+];
+
+const config = {
+    BOT_NAME,
+    COMMAND_PREFIX,
+    STOPWORDS,
+    SENSITIVE_PATTERNS,
+    SYSTEM_PROMPT: `You are ${BOT_NAME}, a warm, professional, and safety-conscious WhatsApp assistant.\n- Always introduce yourself as ${BOT_NAME} when asked who you are.\n- Keep answers short and conversational (2-4 sentences unless the user explicitly asks for more).\n- If you are unsure about something, be honest and offer to help look it up.\n- Never provide harmful, harassing, or disallowed content. Decline requests for personal, medical, legal, or financial advice and instead offer general guidance.`,
+    TYPING_DELAY_MS: 1500,
+    RATE_LIMIT_MS: 2500,
+    MAX_MESSAGE_LENGTH: 1200,
+    CONTEXT_LIMIT: 12,
+    MAX_SAVED_HISTORY: 50,
+    MAX_SAVED_RESPONSES: 100,
+    MAX_SAVED_QUICK_REPLIES: 100,
+    SAFE_FAILURE_MESSAGE: "I'm sorry, but I can't help with that.",
+    PRIVACY_SUMMARY: `${BOT_NAME} stores a limited rolling history per chat to stay helpful. You can clear it any time with ${COMMAND_PREFIX}reset.`,
+    MEMORY_FILE: path.join(__dirname, 'memory.json'),
+    RESPONSES_FILE: path.join(__dirname, 'all_responses.json'),
+    PUPPETEER_OPTIONS: { headless: false }
+};
+
+module.exports = config;

--- a/memory.json
+++ b/memory.json
@@ -20,6 +20,5 @@
       "keywords": ["who are you", "what is your name"],
       "response": "I'm Emponyoo, your friendly WhatsApp assistant powered by OpenAI."
     }
-  ],
-  "chats": {}
+  ]
 }


### PR DESCRIPTION
## Summary
- move all runtime configuration constants into `config.js` and import them from the bot implementation
- streamline persistence so only predefined replies live in `memory.json`, hydrate chat state from `all_responses.json`, and switch disk writes to async helpers
- document the new layout in the README and add LICENSE, Privacy Policy, and Terms of Service files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df59d0a9b48333827970734809d737