### PR TITLE
Add general group responses from JSON triggers

### DIFF
--- a/config.js
+++ b/config.js
@@ -40,6 +40,7 @@ const config = {
     PRIVACY_SUMMARY: `${BOT_NAME} stores a limited rolling history per chat to stay helpful. You can clear it any time with ${COMMAND_PREFIX}reset.`,
     MEMORY_FILE: path.join(__dirname, 'memory.json'),
     RESPONSES_FILE: path.join(__dirname, 'all_responses.json'),
+    GENERAL_RESPONSES_FILE: path.join(__dirname, 'general_responses.json'),
     PUPPETEER_OPTIONS: { headless: false }
 };
 

--- a/general_responses.json
+++ b/general_responses.json
@@ -1,0 +1,14 @@
+[
+  {
+    "keywords": ["good morning", "morning everyone"],
+    "response": "Good morning! Wishing everyone a fantastic day ahead."
+  },
+  {
+    "keywords": ["good night", "night all"],
+    "response": "Good night! Rest well and talk to you soon."
+  },
+  {
+    "keywords": ["congratulations", "congrats"],
+    "response": "Congratulations! Sending you all the best vibes."
+  }
+]


### PR DESCRIPTION
## Summary
- add a dedicated configuration entry for reusable general-response keywords
- introduce shared keyword matching logic and a helper that replies to group triggers without mentions
- store sample general responses in a new `general_responses.json` file

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68df63147f848333ac344aace14fe887