### PR TITLE
Add PHP WhatsApp bot variant for Hostinger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .env
-node_modules/*
-.wwebjs*
+node_modules/
+.wwebjs_auth/
+php-bot/vendor/
+php-bot/.env
+php-bot/storage/*.json

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ A feature-rich WhatsApp chatbot powered by the [whatsapp-web.js](https://github.
    ```
 4. Scan the displayed QR code in WhatsApp to authorise the session.
 
+### Deploying the PHP edition
+
+If you need to stay on PHP-only hosting, use the rewritten bot in [`php-bot/`](./php-bot/README.md). It integrates with the official WhatsApp Cloud API instead of Puppeteer and can be deployed as a standard PHP webhook. Follow the README in that folder for composer installation, webhook verification, and environment variables.
+
 ## Commands
 
 | Command    | Description |

--- a/php-bot/.env.example
+++ b/php-bot/.env.example
@@ -1,0 +1,7 @@
+OPENAI_API_KEY=sk-your-openai-key
+WHATSAPP_TOKEN=your-whatsapp-cloud-api-token
+WHATSAPP_PHONE_ID=your-whatsapp-cloud-phone-number-id
+VERIFY_TOKEN=choose-a-webhook-verify-token
+APP_URL=https://your-domain.example
+BOT_NAME=Emponyoo
+COMMAND_PREFIX=!

--- a/php-bot/README.md
+++ b/php-bot/README.md
@@ -1,0 +1,48 @@
+# Emponyoo WhatsApp Assistant (PHP Edition)
+
+This folder contains a PHP reimplementation of the Emponyoo WhatsApp chatbot that runs on Hostinger (or any PHP 8.1+ host) by connecting to the [WhatsApp Cloud API](https://developers.facebook.com/docs/whatsapp). Conversations are generated with OpenAI's GPT models just like the Node.js version, but the runtime is now PHP-friendly.
+
+## Features
+- ✅ Handles incoming messages via the WhatsApp Cloud API webhook.
+- 🤖 Generates AI replies with `gpt-4o-mini` while keeping a rolling conversation history per contact.
+- 🧠 Shares predefined "quick reply" responses based on keyword matches.
+- ⚙️ Supports the same command set as the Node.js bot (`!help`, `!reset`, `!history`, etc.).
+- 🗃️ Stores chat history and response logs as JSON in the `storage/` directory.
+- 🔐 Loads secrets from a `.env` file compatible with Hostinger's PHP environment.
+
+## Getting started
+1. **Install dependencies** (locally or on the server):
+   ```bash
+   composer install
+   ```
+
+2. **Configure environment variables.** Copy `.env.example` to `.env` and fill in:
+   - `OPENAI_API_KEY` – your OpenAI key.
+   - `WHATSAPP_TOKEN` – the permanent token from Meta's WhatsApp Cloud API.
+   - `WHATSAPP_PHONE_ID` – the phone number ID from the WhatsApp app dashboard.
+   - `VERIFY_TOKEN` – any string you also enter when registering the webhook.
+   - `APP_URL` – the public URL of this PHP app (used only for documentation links).
+
+3. **Expose the webhook endpoint.** Point the WhatsApp Cloud API webhook to:
+   ```
+   https://your-domain.example/php-bot/public/index.php
+   ```
+   When Meta validates the webhook, it sends a GET request that this script answers with the `hub.challenge` token.
+
+4. **Keep storage writable.** The `storage/` directory must be writable by PHP so the bot can track history and logs.
+
+5. **Send a WhatsApp message** to the configured number. Meta forwards it to the webhook, the bot replies via the Cloud API, and the conversation state is persisted in `storage/`.
+
+## Folder structure
+- `composer.json` – project dependencies and PSR-4 autoload rules.
+- `data/` – predefined replies (`memory.json`, `general_responses.json`).
+- `public/index.php` – webhook entry point you deploy to your PHP host.
+- `src/` – PHP source (bot logic, config, utilities).
+- `storage/` – writable folder for generated JSON logs (git keeps it with `.gitkeep`).
+
+## Notes
+- Hostinger's PHP plans allow long-running CLI processes via cron or worker scripts, but the WhatsApp Cloud API only needs an HTTPS webhook, so no background daemon is required.
+- If you also use the Node.js version, keep the `.wwebjs_auth` folder on the Node server. The PHP edition relies solely on Meta's hosted session and does not use Puppeteer.
+- For production you should configure HTTPS, request logging, and error monitoring according to your hosting provider's best practices.
+
+Enjoy running Emponyoo on PHP! 🚀

--- a/php-bot/composer.json
+++ b/php-bot/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "emponyoo/whatsapp-assistant-php",
+    "description": "PHP port of the Emponyoo WhatsApp assistant using the WhatsApp Cloud API and OpenAI.",
+    "type": "project",
+    "require": {
+        "php": "^8.1",
+        "guzzlehttp/guzzle": "^7.8",
+        "vlucas/phpdotenv": "^5.6"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    }
+}

--- a/php-bot/data/general_responses.json
+++ b/php-bot/data/general_responses.json
@@ -1,0 +1,14 @@
+[
+  {
+    "keywords": ["good morning", "morning everyone"],
+    "response": "Good morning! Wishing everyone a fantastic day ahead."
+  },
+  {
+    "keywords": ["good night", "night all"],
+    "response": "Good night! Rest well and talk to you soon."
+  },
+  {
+    "keywords": ["congratulations", "congrats"],
+    "response": "Congratulations! Sending you all the best vibes."
+  }
+]

--- a/php-bot/data/memory.json
+++ b/php-bot/data/memory.json
@@ -1,0 +1,24 @@
+{
+  "predefinedResponses": [
+    {
+      "keywords": ["hello", "hi", "hey"],
+      "response": "Hello! 👋 How can I assist you today?"
+    },
+    {
+      "keywords": ["good morning", "morning"],
+      "response": "Good morning! ☀️ Hope your day is going well."
+    },
+    {
+      "keywords": ["thank you", "thanks", "thx"],
+      "response": "You're welcome! 😊 Let me know if you need anything else."
+    },
+    {
+      "keywords": ["bye", "goodbye", "see you"],
+      "response": "Goodbye! 👋 Catch you later."
+    },
+    {
+      "keywords": ["who are you", "what is your name"],
+      "response": "I'm Emponyoo, your friendly WhatsApp assistant powered by OpenAI."
+    }
+  ]
+}

--- a/php-bot/public/index.php
+++ b/php-bot/public/index.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Bot;
+use Dotenv\Dotenv;
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+$root = dirname(__DIR__);
+if (file_exists($root . '/.env')) {
+    Dotenv::createImmutable($root)->safeLoad();
+}
+
+$verifyToken = getenv('VERIFY_TOKEN') ?: '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    $mode = $_GET['hub_mode'] ?? $_GET['hub.mode'] ?? '';
+    $token = $_GET['hub_verify_token'] ?? $_GET['hub.verify_token'] ?? '';
+    $challenge = $_GET['hub_challenge'] ?? $_GET['hub.challenge'] ?? '';
+
+    if ($mode === 'subscribe' && $token === $verifyToken && $verifyToken !== '') {
+        http_response_code(200);
+        echo $challenge;
+    } else {
+        http_response_code(403);
+        echo 'Invalid verify token.';
+    }
+
+    return;
+}
+
+$raw = file_get_contents('php://input');
+$payload = json_decode($raw ?: '[]', true) ?? [];
+
+try {
+    $bot = new Bot(['basePath' => $root]);
+    $bot->handleWebhook($payload);
+
+    http_response_code(200);
+    header('Content-Type: application/json');
+    echo json_encode(['status' => 'ok']);
+} catch (Throwable $exception) {
+    error_log('Webhook handling failed: ' . $exception->getMessage());
+    http_response_code(500);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'internal_error']);
+}

--- a/php-bot/src/Bot.php
+++ b/php-bot/src/Bot.php
@@ -1,0 +1,402 @@
+<?php
+
+namespace App;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+
+class Bot
+{
+    private Client $graphClient;
+    private Client $openAiClient;
+    private string $openAiKey;
+    private string $whatsappToken;
+    private string $phoneNumberId;
+    private string $botName;
+    private string $commandPrefix;
+    private string $systemPrompt;
+    private array $memory;
+    private array $generalReplies;
+    private array $conversations;
+    private array $responses;
+    private string $conversationsPath;
+    private string $responsesPath;
+
+    private const CONTEXT_LIMIT = 12;
+    private const MAX_RESPONSES_PER_CHAT = 100;
+
+    public function __construct(array $config = [])
+    {
+        $basePath = $config['basePath'] ?? dirname(__DIR__);
+        $dataPath = $basePath . '/data';
+        $storagePath = $basePath . '/storage';
+
+        $this->openAiKey = $config['openAiKey'] ?? getenv('OPENAI_API_KEY') ?: '';
+        $this->whatsappToken = $config['whatsappToken'] ?? getenv('WHATSAPP_TOKEN') ?: '';
+        $this->phoneNumberId = $config['phoneNumberId'] ?? getenv('WHATSAPP_PHONE_ID') ?: '';
+        $this->botName = $config['botName'] ?? getenv('BOT_NAME') ?: 'Emponyoo';
+        $this->commandPrefix = $config['commandPrefix'] ?? getenv('COMMAND_PREFIX') ?: '!';
+        $this->systemPrompt = $config['systemPrompt'] ?? Config::DEFAULT_SYSTEM_PROMPT;
+
+        if ($this->openAiKey === '') {
+            throw new \RuntimeException('OPENAI_API_KEY is not configured.');
+        }
+
+        if ($this->whatsappToken === '' || $this->phoneNumberId === '') {
+            throw new \RuntimeException('WhatsApp Cloud API credentials are missing.');
+        }
+
+        $this->graphClient = new Client([
+            'base_uri' => 'https://graph.facebook.com/v18.0/',
+            'timeout' => 15,
+        ]);
+
+        $this->openAiClient = new Client([
+            'base_uri' => 'https://api.openai.com/v1/',
+            'timeout' => 30,
+        ]);
+
+        $this->memory = JsonStore::load($dataPath . '/memory.json', ['predefinedResponses' => []]);
+        $this->generalReplies = JsonStore::load($dataPath . '/general_responses.json', []);
+
+        $this->conversationsPath = $storagePath . '/conversations.json';
+        $this->responsesPath = $storagePath . '/responses.json';
+
+        $this->conversations = JsonStore::load($this->conversationsPath, []);
+        $this->responses = JsonStore::load($this->responsesPath, []);
+    }
+
+    public function handleWebhook(array $payload): void
+    {
+        if (!isset($payload['entry']) || !is_array($payload['entry'])) {
+            return;
+        }
+
+        foreach ($payload['entry'] as $entry) {
+            $changes = $entry['changes'] ?? [];
+            foreach ($changes as $change) {
+                $value = $change['value'] ?? [];
+                $messages = $value['messages'] ?? [];
+                foreach ($messages as $message) {
+                    if (($message['type'] ?? '') !== 'text') {
+                        continue;
+                    }
+
+                    $text = $message['text']['body'] ?? '';
+                    $from = $message['from'] ?? null;
+                    if ($from === null) {
+                        continue;
+                    }
+
+                    $name = $this->extractContactName($value, $from);
+                    $reply = $this->handleIncomingText($from, $name, $text);
+
+                    if ($reply !== null) {
+                        $this->sendWhatsAppMessage($from, $reply);
+                    }
+                }
+            }
+        }
+
+        $this->persist();
+    }
+
+    private function handleIncomingText(string $chatId, string $name, string $text): ?string
+    {
+        $cleanMessage = trim($text);
+        if ($cleanMessage === '') {
+            return null;
+        }
+
+        $conversation = $this->conversations[$chatId] ?? [
+            'history' => [],
+            'quick_replies' => [],
+            'message_count' => 0,
+            'last_seen' => null,
+        ];
+
+        $conversation['message_count']++;
+        $conversation['last_seen'] = time();
+        $conversation['history'][] = ['role' => 'user', 'content' => $cleanMessage];
+        $conversation['history'] = $this->trimHistory($conversation['history']);
+
+        // Commands
+        if ($this->isCommand($cleanMessage)) {
+            $reply = $this->handleCommand($conversation, $chatId, $name, $cleanMessage);
+            $this->recordReply($chatId, $cleanMessage, $reply, 'command', $conversation);
+            return $reply;
+        }
+
+        // Memory / predefined replies
+        if ($predefined = $this->matchPredefined($cleanMessage, $this->memory['predefinedResponses'] ?? [])) {
+            $conversation['quick_replies'][] = $predefined;
+            $conversation['quick_replies'] = array_slice($conversation['quick_replies'], -10);
+            $reply = $predefined;
+            $this->recordReply($chatId, $cleanMessage, $reply, 'memory', $conversation);
+            return $reply;
+        }
+
+        if ($general = $this->matchPredefined($cleanMessage, $this->generalReplies)) {
+            $conversation['quick_replies'][] = $general;
+            $conversation['quick_replies'] = array_slice($conversation['quick_replies'], -10);
+            $reply = $general;
+            $this->recordReply($chatId, $cleanMessage, $reply, 'general', $conversation);
+            return $reply;
+        }
+
+        $reply = $this->generateConversationalReply($conversation['history'], $name);
+        if ($reply === null) {
+            $reply = "I ran into a problem reaching OpenAI. Please try again soon.";
+        }
+
+        $this->recordReply($chatId, $cleanMessage, $reply, 'openai', $conversation);
+        return $reply;
+    }
+
+    private function isCommand(string $message): bool
+    {
+        return str_starts_with(mb_strtolower($message), mb_strtolower($this->commandPrefix));
+    }
+
+    private function handleCommand(array &$conversation, string $chatId, string $name, string $message): string
+    {
+        $withoutPrefix = trim(mb_substr($message, mb_strlen($this->commandPrefix)));
+        $parts = preg_split('/\s+/', $withoutPrefix, 2);
+        $command = mb_strtolower($parts[0] ?? '');
+        $argument = trim($parts[1] ?? '');
+
+        switch ($command) {
+            case 'help':
+                return Config::HELP_TEXT;
+            case 'reset':
+                $this->resetConversation($chatId);
+                $conversation = [
+                    'history' => [],
+                    'quick_replies' => [],
+                    'message_count' => 0,
+                    'last_seen' => time(),
+                ];
+                return 'Conversation history cleared. We can start fresh!';
+            case 'history':
+                return $this->summariseHistory($conversation['history']);
+            case 'quickreplies':
+                return $this->listQuickReplies($conversation['quick_replies'] ?? []);
+            case 'policy':
+                return Config::SAFETY_POLICY;
+            case 'privacy':
+                return Config::PRIVACY_SUMMARY;
+            case 'stats':
+                return $this->conversationStats($conversation);
+            case 'songs':
+                return $this->structuredList($argument, Config::SONGS_TEMPLATE, 'Provide 3-5 short bullet points with upbeat song suggestions relevant to the request.');
+            case 'plan':
+                return $this->structuredList($argument, Config::PLAN_TEMPLATE, 'Provide 3-5 concise steps the user can follow.');
+            case 'meal':
+                return $this->structuredList($argument, Config::MEAL_TEMPLATE, 'Suggest 3-5 quick meal or snack ideas that match the request.');
+            case 'about':
+                return sprintf("I'm %s, a PHP-powered WhatsApp assistant that chats using OpenAI.", $this->botName);
+            default:
+                return "I don't recognise that command. Try !help for options.";
+        }
+    }
+
+    private function resetConversation(string $chatId): void
+    {
+        unset($this->conversations[$chatId]);
+        unset($this->responses[$chatId]);
+        $this->persist();
+    }
+
+    private function summariseHistory(array $history): string
+    {
+        $dialogue = array_filter($history, fn ($entry) => in_array($entry['role'], ['user', 'assistant'], true));
+        if (empty($dialogue)) {
+            return 'I do not have any saved context yet. Say hi to get started!';
+        }
+
+        $lines = array_map(function ($entry) {
+            $role = $entry['role'] === 'assistant' ? 'Me' : 'You';
+            return sprintf('%s: %s', $role, $entry['content']);
+        }, array_slice($dialogue, -10));
+
+        return "Recent context:\n" . implode("\n", $lines);
+    }
+
+    private function listQuickReplies(array $quickReplies): string
+    {
+        if (empty($quickReplies)) {
+            return 'No quick replies yet — I will let you know when I spot a perfect match!';
+        }
+
+        $unique = array_values(array_unique($quickReplies));
+        return "Quick replies I've shared recently:\n- " . implode("\n- ", $unique);
+    }
+
+    private function conversationStats(array $conversation): string
+    {
+        $count = $conversation['message_count'] ?? 0;
+        $lastSeen = $conversation['last_seen'] ?? null;
+        $lastSeenText = $lastSeen ? date('Y-m-d H:i', $lastSeen) : 'never';
+
+        return sprintf(
+            "We've exchanged %d message(s). Last activity: %s.",
+            $count,
+            $lastSeenText
+        );
+    }
+
+    private function structuredList(string $topic, string $template, string $instruction): string
+    {
+        if ($topic === '') {
+            return 'Please add a topic after the command, e.g. !songs focus or !plan exam prep.';
+        }
+
+        $messages = [
+            ['role' => 'system', 'content' => $this->systemPrompt],
+            ['role' => 'user', 'content' => sprintf('%s Topic: %s', $instruction, $topic)],
+        ];
+
+        $result = $this->requestChatCompletion($messages, 0.6);
+        if ($result === null) {
+            return 'I could not generate that list right now. Please try again later.';
+        }
+
+        return sprintf($template, $topic, $result);
+    }
+
+    private function matchPredefined(string $message, array $entries): ?string
+    {
+        $normalised = mb_strtolower($message);
+
+        foreach ($entries as $entry) {
+            $keywords = $entry['keywords'] ?? [];
+            $response = $entry['response'] ?? null;
+            if (!$keywords || !$response) {
+                continue;
+            }
+
+            foreach ($keywords as $keyword) {
+                $keywordNormalised = mb_strtolower($keyword);
+                if (str_contains($normalised, $keywordNormalised)) {
+                    return $response;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function generateConversationalReply(array $history, string $name): ?string
+    {
+        $messages = [
+            ['role' => 'system', 'content' => $this->systemPrompt],
+        ];
+
+        foreach (array_slice($history, -self::CONTEXT_LIMIT) as $entry) {
+            if (!isset($entry['role'], $entry['content'])) {
+                continue;
+            }
+
+            $messages[] = $entry;
+        }
+
+        $messages[] = ['role' => 'system', 'content' => sprintf('The user is named %s.', $name)];
+
+        return $this->requestChatCompletion($messages, 0.7);
+    }
+
+    private function requestChatCompletion(array $messages, float $temperature): ?string
+    {
+        try {
+            $response = $this->openAiClient->post('chat/completions', [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $this->openAiKey,
+                    'Content-Type' => 'application/json',
+                ],
+                'json' => [
+                    'model' => 'gpt-4o-mini',
+                    'messages' => $messages,
+                    'temperature' => $temperature,
+                ],
+            ]);
+        } catch (GuzzleException $exception) {
+            error_log('OpenAI request failed: ' . $exception->getMessage());
+            return null;
+        }
+
+        $data = json_decode((string) $response->getBody(), true);
+        $content = $data['choices'][0]['message']['content'] ?? null;
+
+        if (!is_string($content) || trim($content) === '') {
+            return null;
+        }
+
+        return trim($content);
+    }
+
+    private function sendWhatsAppMessage(string $to, string $message): void
+    {
+        try {
+            $this->graphClient->post($this->phoneNumberId . '/messages', [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $this->whatsappToken,
+                    'Content-Type' => 'application/json',
+                ],
+                'json' => [
+                    'messaging_product' => 'whatsapp',
+                    'to' => $to,
+                    'type' => 'text',
+                    'text' => ['body' => $message],
+                ],
+            ]);
+        } catch (GuzzleException $exception) {
+            error_log('Failed to send WhatsApp message: ' . $exception->getMessage());
+        }
+    }
+
+    private function recordReply(string $chatId, string $message, string $reply, string $source, array $conversation): void
+    {
+        $conversation['history'][] = ['role' => 'assistant', 'content' => $reply];
+        $conversation['history'] = $this->trimHistory($conversation['history']);
+        $this->conversations[$chatId] = $conversation;
+
+        $log = $this->responses[$chatId] ?? [];
+        $log[] = [
+            'message' => $message,
+            'reply' => $reply,
+            'source' => $source,
+            'timestamp' => date(DATE_ATOM),
+        ];
+
+        if (count($log) > self::MAX_RESPONSES_PER_CHAT) {
+            $log = array_slice($log, -self::MAX_RESPONSES_PER_CHAT);
+        }
+
+        $this->responses[$chatId] = $log;
+    }
+
+    private function trimHistory(array $history): array
+    {
+        if (count($history) <= self::CONTEXT_LIMIT * 2) {
+            return $history;
+        }
+
+        return array_slice($history, -self::CONTEXT_LIMIT * 2);
+    }
+
+    private function extractContactName(array $value, string $fallback): string
+    {
+        $contacts = $value['contacts'] ?? [];
+        if (!empty($contacts[0]['profile']['name'])) {
+            return $contacts[0]['profile']['name'];
+        }
+
+        return $fallback;
+    }
+
+    private function persist(): void
+    {
+        JsonStore::save($this->conversationsPath, $this->conversations);
+        JsonStore::save($this->responsesPath, $this->responses);
+    }
+}

--- a/php-bot/src/Config.php
+++ b/php-bot/src/Config.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App;
+
+class Config
+{
+    public const DEFAULT_SYSTEM_PROMPT = <<<PROMPT
+You are Emponyoo, a friendly WhatsApp assistant. Be concise, positive, and practical. Use clear formatting and emojis sparingly. Never claim to be an official WhatsApp service. If you are unsure of an answer, admit it and suggest alternative steps the user can take.
+PROMPT;
+
+    public const PRIVACY_SUMMARY = <<<TEXT
+I remember recent chats so I can reply naturally. Data is only stored in this Hostinger account and can be cleared with the !reset command. I never share chat data with anyone else.
+TEXT;
+
+    public const SAFETY_POLICY = <<<TEXT
+I follow OpenAI safety policies. I avoid sharing harmful instructions, personal data, or anything illegal.
+TEXT;
+
+    public const HELP_TEXT = <<<TEXT
+Here are my commands:
+- !help — Show this menu
+- !reset — Clear our recent chat memory
+- !history — Summarise the latest context I am using
+- !quickreplies — Show the quick replies I have used with you
+- !policy — Display my safety approach
+- !privacy — Summarise how I store chat data
+- !stats — Share our recent usage stats
+- !songs <mood> — Suggest a short song list
+- !plan <goal> — Draft a quick plan
+- !meal <ingredients> — Offer fast meal ideas
+- !about — Describe who I am
+TEXT;
+
+    public const SONGS_TEMPLATE = "Here are some songs for %s:\n%s";
+    public const PLAN_TEMPLATE = "Quick plan for %s:\n%s";
+    public const MEAL_TEMPLATE = "Here are some meal ideas for %s:\n%s";
+}

--- a/php-bot/src/JsonStore.php
+++ b/php-bot/src/JsonStore.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App;
+
+class JsonStore
+{
+    public static function load(string $path, $default)
+    {
+        if (!file_exists($path)) {
+            return $default;
+        }
+
+        $contents = file_get_contents($path);
+        if ($contents === false || $contents === '') {
+            return $default;
+        }
+
+        $data = json_decode($contents, true);
+        return $data === null ? $default : $data;
+    }
+
+    public static function save(string $path, $data): void
+    {
+        $dir = dirname($path);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+
+        file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE), LOCK_EX);
+    }
+}


### PR DESCRIPTION
## Summary
- add a PHP webhook implementation of the WhatsApp assistant that targets the WhatsApp Cloud API
- include composer metadata, environment template, and documentation to deploy the PHP edition on Hostinger
- update the root README and gitignore to reference the new PHP option and ignore generated assets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df6a9d9fd48333ba8e43a8e2cf368f