### PR TITLE
Support media-rich general replies

### DIFF
--- a/general_responses.json
+++ b/general_responses.json
@@ -10,5 +10,21 @@
   {
     "keywords": ["congratulations", "congrats"],
     "response": "Congratulations! Sending you all the best vibes."
+  },
+  {
+    "keywords": ["cheer up", "you got this", "motivation"],
+    "response": {
+      "text": "Here's a little boost to brighten your day! 💪",
+      "mediaUrl": "https://www.gstatic.com/webp/gallery/1.jpg",
+      "caption": "Keep going—you're doing great!"
+    }
+  },
+  {
+    "keywords": ["party time", "celebration", "let's party"],
+    "response": {
+      "text": "Party mode activated! 🎉",
+      "stickerUrl": "https://www.gstatic.com/webp/gallery/2.webp",
+      "sendAsSticker": true
+    }
   }
 ]

--- a/php-bot/src/Bot.php
+++ b/php-bot/src/Bot.php
@@ -271,14 +271,35 @@ class Bot
         foreach ($entries as $entry) {
             $keywords = $entry['keywords'] ?? [];
             $response = $entry['response'] ?? null;
-            if (!$keywords || !$response) {
+            if (!$keywords) {
+                continue;
+            }
+
+            $responseText = '';
+            if (is_array($response)) {
+                $text = trim((string)($response['text'] ?? ''));
+                $caption = trim((string)($response['caption'] ?? ''));
+                if ($text !== '') {
+                    $responseText = $text;
+                } elseif ($caption !== '') {
+                    $responseText = $caption;
+                } elseif (!empty($response['stickerUrl'])) {
+                    $responseText = '[sticker]';
+                } elseif (!empty($response['mediaUrl'])) {
+                    $responseText = '[media]';
+                }
+            } elseif (is_string($response)) {
+                $responseText = trim($response);
+            }
+
+            if ($responseText === '') {
                 continue;
             }
 
             foreach ($keywords as $keyword) {
                 $keywordNormalised = mb_strtolower($keyword);
                 if (str_contains($normalised, $keywordNormalised)) {
-                    return $response;
+                    return $responseText;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- normalize predefined response entries so they can include media URLs, stickers, and captions
- update the WhatsApp bot to send media or sticker replies (with fallbacks) and refresh the bundled general responses dataset
- make the PHP helper bot tolerate structured response objects by falling back to text descriptions

## Testing
- php -l php-bot/src/Bot.php

------
https://chatgpt.com/codex/tasks/task_e_68e0524739e48333a76b6a50211ba600