### PR TITLE
Improve OpenAI service resiliency

### DIFF
--- a/microservices/image.js
+++ b/microservices/image.js
@@ -3,6 +3,34 @@ const OpenAI = require('openai');
 
 const DEFAULT_LIMIT = Number(process.env.IMAGE_GENERATION_LIMIT || 3);
 const WINDOW_MS = Number(process.env.IMAGE_GENERATION_WINDOW_MS || 24 * 60 * 60 * 1000);
+const MAX_RETRIES = Number(process.env.IMAGE_MAX_RETRIES || 2);
+const BASE_RETRY_DELAY_MS = Number(process.env.IMAGE_RETRY_DELAY_MS || 500);
+
+async function withRetry(fn, { maxRetries = MAX_RETRIES, baseDelay = BASE_RETRY_DELAY_MS } = {}) {
+    let attempt = 0;
+
+    while (true) {
+        try {
+            return await fn();
+        } catch (error) {
+            const status = error?.status ?? error?.response?.status;
+            const isRetryable = [408, 409, 429, 500, 502, 503, 504].includes(status);
+
+            if (attempt >= maxRetries || !isRetryable) {
+                throw error;
+            }
+
+            const retryAfterHeader = error?.headers?.get?.('retry-after');
+            const retryAfterMs = retryAfterHeader ? Number(retryAfterHeader) * 1000 : null;
+            const delayMs = retryAfterMs && !Number.isNaN(retryAfterMs)
+                ? retryAfterMs
+                : baseDelay * Math.pow(2, attempt);
+
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+            attempt += 1;
+        }
+    }
+}
 
 function startImageService({ port }) {
     if (!process.env.OPENAI_API_KEY) {
@@ -51,35 +79,69 @@ function startImageService({ port }) {
         }
 
         try {
-            const result = await openai.images.generate({
-                model: 'gpt-image-1',
-                prompt: trimmedPrompt,
-                size,
-                n: 1,
-                response_format: 'b64_json'
-            });
+            const result = await withRetry(
+                () => openai.images.generate({
+                    model: 'gpt-image-1',
+                    prompt: trimmedPrompt,
+                    size,
+                    n: 1
+                })
+            );
 
-            const image = result?.data?.[0]?.b64_json;
+            const payload = result?.data?.[0] || {};
+            const image = payload.b64_json || null;
+            const imageUrl = payload.url || null;
 
-            if (!image) {
+            if (!image && !imageUrl) {
                 return res.status(502).json({ error: 'Image model returned an empty response.' });
             }
 
-            recent.push(Date.now());
+            const now = Date.now();
+            recent.push(now);
             usage.set(trimmedChatId, recent);
 
             const remaining = Math.max(DEFAULT_LIMIT - recent.length, 0);
+            const resetInMs = Math.max(WINDOW_MS - (now - recent[0]), 0);
 
-            res.json({
-                images: [{ base64: image, mimeType: 'image/png' }],
+            if (image) {
+                return res.json({
+                    images: [{ base64: image, mimeType: 'image/png' }],
+                    usage: {
+                        limit: DEFAULT_LIMIT,
+                        remaining,
+                        resetInMs
+                    }
+                });
+            }
+
+            return res.json({
+                images: [{ url: imageUrl }],
                 usage: {
                     limit: DEFAULT_LIMIT,
                     remaining,
-                    resetInMs: Math.max(WINDOW_MS - (Date.now() - recent[0]), 0)
+                    resetInMs
                 }
             });
         } catch (error) {
+            const status = error?.status ?? error?.response?.status ?? 500;
+            const message = error?.error?.message || error?.message || 'Image service unavailable. Please try again later.';
+
             console.error('[ImageService] Unable to generate image:', error);
+
+            if (status === 429) {
+                return res.status(429).json({
+                    error: 'Image service is rate limited. Please retry shortly.',
+                    details: message
+                });
+            }
+
+            if (status === 400) {
+                return res.status(400).json({
+                    error: 'Invalid image request.',
+                    details: message
+                });
+            }
+
             res.status(500).json({ error: 'Image service unavailable. Please try again later.' });
         }
     });

--- a/microservices/moderation.js
+++ b/microservices/moderation.js
@@ -1,6 +1,35 @@
 const express = require('express');
 const OpenAI = require('openai');
 
+const MAX_RETRIES = Number(process.env.MODERATION_MAX_RETRIES || 2);
+const BASE_RETRY_DELAY_MS = Number(process.env.MODERATION_RETRY_DELAY_MS || 250);
+
+async function withRetry(fn, { maxRetries = MAX_RETRIES, baseDelay = BASE_RETRY_DELAY_MS } = {}) {
+    let attempt = 0;
+
+    while (true) {
+        try {
+            return await fn();
+        } catch (error) {
+            const status = error?.status ?? error?.response?.status;
+            const isRetryable = [408, 409, 429, 500, 502, 503, 504].includes(status);
+
+            if (attempt >= maxRetries || !isRetryable) {
+                throw error;
+            }
+
+            const retryAfterHeader = error?.headers?.get?.('retry-after');
+            const retryAfterMs = retryAfterHeader ? Number(retryAfterHeader) * 1000 : null;
+            const delayMs = retryAfterMs && !Number.isNaN(retryAfterMs)
+                ? retryAfterMs
+                : baseDelay * Math.pow(2, attempt);
+
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+            attempt += 1;
+        }
+    }
+}
+
 function startModerationService({ port }) {
     if (!process.env.OPENAI_API_KEY) {
         throw new Error('Missing OPENAI_API_KEY for moderation service.');
@@ -19,10 +48,12 @@ function startModerationService({ port }) {
         }
 
         try {
-            const result = await openai.moderations.create({
-                model: 'omni-moderation-latest',
-                input
-            });
+            const result = await withRetry(
+                () => openai.moderations.create({
+                    model: 'omni-moderation-latest',
+                    input
+                })
+            );
 
             const flagged = result?.results?.[0]?.flagged ?? false;
             const categories = Object.entries(result?.results?.[0]?.categories || {})
@@ -35,8 +66,17 @@ function startModerationService({ port }) {
                 type
             });
         } catch (error) {
+            const status = error?.status ?? error?.response?.status ?? 500;
+            const message = error?.error?.message || error?.message || 'Moderation service unavailable. Please try again later.';
+
             console.error('[ModerationService] Unable to process moderation request:', error);
-            res.status(500).json({ error: 'Moderation service unavailable. Please try again later.' });
+
+            res.status(status === 429 ? 429 : 500).json({
+                error: status === 429
+                    ? 'Moderation service is rate limited. Please retry after a short delay.'
+                    : 'Moderation service unavailable. Please try again later.',
+                details: status === 429 ? message : undefined
+            });
         }
     });
 


### PR DESCRIPTION
## Summary
- add configurable retry handling and clearer responses to the moderation microservice to better tolerate transient OpenAI failures
- update the image microservice to remove unsupported parameters, add retry logic, and improve success and error payloads

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e05bea46ec8333963d302af70ad2fb