### PR TITLE
Optimize moderation and response timing

### DIFF
--- a/config.js
+++ b/config.js
@@ -30,17 +30,22 @@ const config = {
     SENSITIVE_PATTERNS,
     SYSTEM_PROMPT: `You are ${BOT_NAME}, a warm, professional, and safety-conscious WhatsApp assistant.\n- Always introduce yourself as ${BOT_NAME} when asked who you are.\n- Keep answers short and conversational (2-4 sentences unless the user explicitly asks for more).\n- If you are unsure about something, be honest and offer to help look it up.\n- Never provide harmful, harassing, or disallowed content. Decline requests for personal, medical, legal, or financial advice and instead offer general guidance.`,
     TYPING_DELAY_MS: 1500,
+    MIN_TYPING_DELAY_MS: 250,
+    TYPING_DELAY_PER_CHAR_MS: 20,
     RATE_LIMIT_MS: 2500,
     MAX_MESSAGE_LENGTH: 1200,
     CONTEXT_LIMIT: 12,
     MAX_SAVED_HISTORY: 50,
     MAX_SAVED_RESPONSES: 100,
     MAX_SAVED_QUICK_REPLIES: 100,
+    SAVE_DEBOUNCE_MS: 750,
     SAFE_FAILURE_MESSAGE: "I'm sorry, but I can't help with that.",
     PRIVACY_SUMMARY: `${BOT_NAME} stores a limited rolling history per chat to stay helpful. You can clear it any time with ${COMMAND_PREFIX}reset.`,
     MEMORY_FILE: path.join(__dirname, 'memory.json'),
     RESPONSES_FILE: path.join(__dirname, 'all_responses.json'),
     GENERAL_RESPONSES_FILE: path.join(__dirname, 'general_responses.json'),
+    MODERATION_CACHE_TTL_MS: 5 * 60 * 1000,
+    MODERATION_CACHE_MAX_ENTRIES: 500,
     PUPPETEER_OPTIONS: { headless: false }
 };
 


### PR DESCRIPTION
## Summary
- cache moderation decisions and reuse them while skipping unnecessary output moderation checks
- compute typing delays dynamically, reuse compiled bot name regex, and improve rate limit ordering to respond faster
- debounce response history writes and flush immediately on resets to reduce disk churn

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e3063b946c8333beb971f0ae9d9f21